### PR TITLE
fix: link vibes cards to /featured-strains/

### DIFF
--- a/apparel/black-apparel/index.html
+++ b/apparel/black-apparel/index.html
@@ -62,7 +62,7 @@
           </div>
           <ul class="flex-col center-nav slow-load">
             <li class="">
-              <a href="/">Home </a>
+              <a href="/home/">Home </a>
             </li>
             <li class="">
               <a href="/featured-strains/"

--- a/apparel/blue-apparel/index.html
+++ b/apparel/blue-apparel/index.html
@@ -58,7 +58,7 @@
       </div>
       <ul class="flex-col center-nav slow-load">
         <li class="">
-          <a href="/">Home </a>
+          <a href="/home/">Home </a>
         </li>
         <li class="">
           <a href="/featured-strains/">Featured Strains

--- a/apparel/index.html
+++ b/apparel/index.html
@@ -63,7 +63,7 @@
         </div>
         <ul class="flex-col center-nav slow-load">
           <li class="">
-            <a href="../">Home </a>
+            <a href="../home/">Home </a>
           </li>
           <li class="">
             <a href="../featured-strains/">Featured Strains

--- a/apparel/tan-apparel/index.html
+++ b/apparel/tan-apparel/index.html
@@ -57,7 +57,7 @@
         </div>
         <ul class="flex-col center-nav slow-load">
           <li class="home-li-nav active">
-            <a href="/">Home </a>
+            <a href="/home/">Home </a>
           </li>
           <li class="">
             <a href="/featured-strains/"

--- a/apparel/white-apparel/index.html
+++ b/apparel/white-apparel/index.html
@@ -57,7 +57,7 @@
       </div>
       <ul class="flex-col center-nav slow-load">
         <li class="">
-          <a href="/">Home </a>
+          <a href="/home/">Home </a>
         </li>
         <li class="">
           <a href="/featured-strains/">Featured Strains

--- a/assets/css/home.css
+++ b/assets/css/home.css
@@ -159,6 +159,8 @@ html {
 
   position: relative;
   color: var(--white);
+
+  transition: all 0.2s ease-in;
 }
 
 @media (min-width: 480px) {
@@ -209,6 +211,10 @@ html {
   object-fit: cover;
   object-position: center;
   z-index: 1;
+}
+
+.vibe:hover {
+  transform: translateY(-5px);
 }
 
 /* ScrollReveal extension */

--- a/featured-strains/index.html
+++ b/featured-strains/index.html
@@ -66,7 +66,7 @@
         </div>
         <ul class="flex-col center-nav slow-load">
           <li class="">
-            <a href="../">Home </a>
+            <a href="../home/">Home </a>
           </li>
           <li class="active">
             <a href="#" class="active">Featured Strains

--- a/home/index.html
+++ b/home/index.html
@@ -133,46 +133,46 @@
 
       <div class="vibes-container">
         <!-- Creative Vibe -->
-        <div class="vibe reveal">
+        <a href="../featured-strains/" class="vibe reveal">
           <img src="../assets/images/creative.png" alt="">
 
           <div class="vibe-cover vibe-creative">Strains for <br> <strong>Being Creative</strong></div>
-        </div>
+        </a>
 
         <!-- Social Vibe -->
-        <div class="vibe reveal">
+        <a href="../featured-strains/" class="vibe reveal">
           <img src="../assets/images/Social.png" alt="">
 
           <div class="vibe-cover vibe-social">Strains for <br> <strong>Being Social</strong></div>
-        </div>
+        </a>
 
         <!-- Relaxing Vibe -->
-        <div class="vibe reveal">
+        <a href="../featured-strains/" class="vibe reveal">
           <img src="../assets/images/Cloud 9.png" alt="">
 
           <div class="vibe-cover vibe-relaxing">Strains for <br> <strong>Relaxing</strong></div>
-        </div>
+        </a>
 
         <!-- Live Music Vibe -->
-        <div class="vibe reveal">
+        <a href="../featured-strains/" class="vibe reveal">
           <img src="../assets/images/Experience.webp" alt="">
 
           <div class="vibe-cover vibe-music">Strains for <br> <strong>Live Music</strong></div>
-        </div>
+        </a>
 
         <!-- Vibe -->
-        <div class="vibe reveal">
+        <a href="../featured-strains/" class="vibe reveal">
           <img src="../assets/images/Chill.png" alt="">
 
           <div class="vibe-cover vibe-creative">Strains for <br> <strong>Being Creative</strong></div>
-        </div>
+        </a>
 
         <!-- Vibe -->
-        <div class="vibe reveal">
+        <a href="../featured-strains/" class="vibe reveal">
           <img src="../assets/images/Adventure.png" alt="">
 
           <div class="vibe-cover vibe-social">Strains for <br> <strong>Being Social</strong></div>
-        </div>
+        </a>
       </div>
     </section>
     <!-- End Vibes Section -->

--- a/map/google/index.html
+++ b/map/google/index.html
@@ -121,7 +121,7 @@
         </div>
         <ul class="flex-col center-nav slow-load">
           <li class="home-li-nav">
-            <a href="/">Home </a>
+            <a href="/home/">Home </a>
           </li>
           <li class="">
             <a href="../featured-strains/">Featured Strains

--- a/map/index.html
+++ b/map/index.html
@@ -266,7 +266,7 @@
           </div>
           <ul class="flex-col center-nav slow-load">
             <li class="home-li-nav">
-              <a href="/">Home </a>
+              <a href="/home/">Home </a>
             </li>
             <li class="">
               <a href="../featured-strains/">Featured Strains


### PR DESCRIPTION
### Description

Clicking on the vibes cards leads to the `/featured-strains/`.

<img src="https://user-images.githubusercontent.com/87664239/204922803-579d61d1-d388-4943-a7a0-1b04ac4ffe67.png" width=70%>

### Issue

The same issue with the page reloading when it's supposed to link to an external link still occurs, so it doesn't actually link to the `/featured-strains/` page.
The possible cause might be a library that's being used on the page, but I'm still making my research.
The only way I've found to work is opening in a new tab (`target="_blank"`).

### Other Changes:

- Make the **Home** link in the top navigation bar link to `/home` (instead of the root directory where the age prompt will be seen).