### PR TITLE
feat: convert apparel images to links

### DIFF
--- a/apparel/index.html
+++ b/apparel/index.html
@@ -106,7 +106,7 @@
     <section class="apparel">
       <!-- Swiper -->
       <div class="swiper mySwiper">
-        <div class="swiper-wrapper">
+        <a href="https://example.com" target="_blank" class="swiper-wrapper">
           <div class="swiper-slide">
             <img src="../assets/images/stylish_happy_young_adult_in_a_black_hoodie_at_conc.png" alt="">
           </div>
@@ -119,7 +119,7 @@
           <div class="swiper-slide">
             <img src="../assets/images/stylish_happy_young_woman_in_a_white_baseball_hat.png" alt="">
           </div>
-        </div>
+        </a>
         <div class="swiper-pagination"></div>
       </div>
       <div class="apparel__cta">

--- a/apparel/index.html
+++ b/apparel/index.html
@@ -8,13 +8,13 @@
   <!-- Primary Meta Tags -->
   <title>Apparel — Sesshin</title>
   <meta name="title" content="Apparel — Sesshin" />
-  <meta name="description" content="Elevate Your Sessh" />
+  <meta name="description" content="Experience euphoria" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
   <meta property="og:url" content="" />
   <meta property="og:title" content="Apparel — Sesshin" />
-  <meta property="og:description" content="Elevate Your Sessh" />
+  <meta property="og:description" content="Experience euphoria" />
   <meta property="og:image" content="https://i.ibb.co/yfWpmF9/sesshin.png" />
   <meta property="og:site_name" content="Apparel — Sesshin" />
 
@@ -22,7 +22,7 @@
   <meta property="twitter:card" content="summary_large_image" />
   <meta property="twitter:url" content="" />
   <meta property="twitter:title" content="Apparel — Sesshin" />
-  <meta property="twitter:description" content="Elevate Your Sessh" />
+  <meta property="twitter:description" content="Experience euphoria" />
   <meta property="twitter:image" content="https://i.ibb.co/yfWpmF9/sesshin.png" />
 
   <!-- Styles -->
@@ -148,7 +148,7 @@
                   color: #6b6b6b;
                   text-align: center;
                 ">
-              Elevate your Sessh
+              Experience euphoria
             </h2>
             <div class="line"></div>
           </div>

--- a/archive/black-apparel/index.html
+++ b/archive/black-apparel/index.html
@@ -8,13 +8,13 @@
   <!-- Primary Meta Tags -->
   <title>Black Apparel — Sesshin</title>
   <meta name="title" content="Black Apparel — Sesshin" />
-  <meta name="description" content="Elevate Your Sessh" />
+  <meta name="description" content="Experience euphoria" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
   <meta property="og:url" content="" />
   <meta property="og:title" content="Black Apparel — Sesshin" />
-  <meta property="og:description" content="Elevate Your Sessh" />
+  <meta property="og:description" content="Experience euphoria" />
   <meta property="og:image" content="https://i.ibb.co/yfWpmF9/sesshin.png" />
   <meta property="og:site_name" content="Black Apparel — Sesshin" />
 
@@ -22,7 +22,7 @@
   <meta property="twitter:card" content="summary_large_image" />
   <meta property="twitter:url" content="" />
   <meta property="twitter:title" content="Black Apparel — Sesshin" />
-  <meta property="twitter:description" content="Elevate Your Sessh" />
+  <meta property="twitter:description" content="Experience euphoria" />
   <meta property="twitter:image" content="https://i.ibb.co/yfWpmF9/sesshin.png" />
 
   <!-- Styles -->

--- a/archive/blue-apparel/index.html
+++ b/archive/blue-apparel/index.html
@@ -8,13 +8,13 @@
   <!-- Primary Meta Tags -->
   <title>Blue Apparel — Sesshin</title>
   <meta name="title" content="Blue Apparel — Sesshin" />
-  <meta name="description" content="Elevate Your Sessh" />
+  <meta name="description" content="Experience euphoria" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
   <meta property="og:url" content="" />
   <meta property="og:title" content="Blue Apparel — Sesshin" />
-  <meta property="og:description" content="Elevate Your Sessh" />
+  <meta property="og:description" content="Experience euphoria" />
   <meta property="og:image" content="https://i.ibb.co/yfWpmF9/sesshin.png" />
   <meta property="og:site_name" content="Blue Apparel — Sesshin" />
 
@@ -22,7 +22,7 @@
   <meta property="twitter:card" content="summary_large_image" />
   <meta property="twitter:url" content="" />
   <meta property="twitter:title" content="Blue Apparel — Sesshin" />
-  <meta property="twitter:description" content="Elevate Your Sessh" />
+  <meta property="twitter:description" content="Experience euphoria" />
   <meta property="twitter:image" content="https://i.ibb.co/yfWpmF9/sesshin.png" />
 
   <!-- Styles -->

--- a/archive/tan-apparel/index.html
+++ b/archive/tan-apparel/index.html
@@ -8,13 +8,13 @@
   <!-- Primary Meta Tags -->
   <title>Tan Apparel — Sesshin</title>
   <meta name="title" content="Tan Apparel — Sesshin" />
-  <meta name="description" content="Elevate Your Sessh" />
+  <meta name="description" content="Experience euphoria" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
   <meta property="og:url" content="" />
   <meta property="og:title" content="Tan Apparel — Sesshin" />
-  <meta property="og:description" content="Elevate Your Sessh" />
+  <meta property="og:description" content="Experience euphoria" />
   <meta property="og:image" content="https://i.ibb.co/yfWpmF9/sesshin.png" />
   <meta property="og:site_name" content="Tan Apparel — Sesshin" />
 
@@ -22,7 +22,7 @@
   <meta property="twitter:card" content="summary_large_image" />
   <meta property="twitter:url" content="" />
   <meta property="twitter:title" content="Tan Apparel — Sesshin" />
-  <meta property="twitter:description" content="Elevate Your Sessh" />
+  <meta property="twitter:description" content="Experience euphoria" />
   <meta property="twitter:image" content="https://i.ibb.co/yfWpmF9/sesshin.png" />
 
   <!-- Styles -->

--- a/archive/white-apparel/index.html
+++ b/archive/white-apparel/index.html
@@ -8,13 +8,13 @@
   <!-- Primary Meta Tags -->
   <title>White Apparel — Sesshin</title>
   <meta name="title" content="White Apparel — Sesshin" />
-  <meta name="description" content="Elevate Your Sessh" />
+  <meta name="description" content="Experience euphoria" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
   <meta property="og:url" content="" />
   <meta property="og:title" content="White Apparel — Sesshin" />
-  <meta property="og:description" content="Elevate Your Sessh" />
+  <meta property="og:description" content="Experience euphoria" />
   <meta property="og:image" content="https://i.ibb.co/yfWpmF9/sesshin.png" />
   <meta property="og:site_name" content="White Apparel — Sesshin" />
 
@@ -22,7 +22,7 @@
   <meta property="twitter:card" content="summary_large_image" />
   <meta property="twitter:url" content="" />
   <meta property="twitter:title" content="White Apparel — Sesshin" />
-  <meta property="twitter:description" content="Elevate Your Sessh" />
+  <meta property="twitter:description" content="Experience euphoria" />
   <meta property="twitter:image" content="https://i.ibb.co/yfWpmF9/sesshin.png" />
 
   <!-- Styles -->

--- a/home/index.html
+++ b/home/index.html
@@ -5,7 +5,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 
-  <title>Sesshin | Elevate your Sessh </title>
+  <title>Sesshin | Experience euphoria </title>
   <meta name="description" content="Experience euphoria" />
   <meta name="robots" content="index, follow" />
 
@@ -14,7 +14,7 @@
   <meta property="og:discription" content="Experience euphoria" />
   <meta property="og:site_name" content="Sesshin" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="media/site/61c083ecf8-1631837366/meta-image-emble-860x540-q72.jpg" />
+  <meta property="og:image" content="https://i.ibb.co/yfWpmF9/sesshin.png" />
 
   <link rel="canonical" href="index.html" />
 
@@ -186,7 +186,7 @@
           <!-- <div class="flex-col">
             <div class="footer-text">
               <div class="line"></div>
-              <h2 style="padding: 0em 2em 0em 2em; color: #6b6b6b; text-align: center">Elevate your Sessh</h2>
+              <h2 style="padding: 0em 2em 0em 2em; color: #6b6b6b; text-align: center">Experience euphoria</h2>
               <div class="line"></div>
             </div>
 

--- a/index.html
+++ b/index.html
@@ -5,16 +5,16 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no" />
 
-  <title>Sesshin | Elevate your Sessh </title>
+  <title>Sesshin | Experience euphoria </title>
   <meta name="description" content="Experience euphoria" />
   <meta name="robots" content="index, follow" />
 
   <meta property="og:url" content="index.html" />
   <meta property="og:title" content="Sesshin | Experience euphoria" />
-  <meta property="og:discription" content="Experience euphoria" />
+  <meta property="og:description" content="Experience euphoria" />
   <meta property="og:site_name" content="Sesshin" />
   <meta property="og:type" content="website" />
-  <meta property="og:image" content="media/site/61c083ecf8-1631837366/meta-image-emble-860x540-q72.jpg" />
+  <meta property="og:image" content="https://i.ibb.co/yfWpmF9/sesshin.png" />
 
   <style>
     html,

--- a/map/google/index.html
+++ b/map/google/index.html
@@ -8,13 +8,13 @@
   <!-- Primary Meta Tags -->
   <title>Apparel — Sesshin</title>
   <meta name="title" content="Apparel — Sesshin" />
-  <meta name="description" content="Elevate Your Sessh" />
+  <meta name="description" content="Experience euphoria" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
   <meta property="og:url" content="" />
   <meta property="og:title" content="Apparel — Sesshin" />
-  <meta property="og:description" content="Elevate Your Sessh" />
+  <meta property="og:description" content="Experience euphoria" />
   <meta property="og:image" content="https://i.ibb.co/yfWpmF9/sesshin.png" />
   <meta property="og:site_name" content="Apparel — Sesshin" />
 
@@ -22,7 +22,7 @@
   <meta property="twitter:card" content="summary_large_image" />
   <meta property="twitter:url" content="" />
   <meta property="twitter:title" content="Apparel — Sesshin" />
-  <meta property="twitter:description" content="Elevate Your Sessh" />
+  <meta property="twitter:description" content="Experience euphoria" />
   <meta property="twitter:image" content="https://i.ibb.co/yfWpmF9/sesshin.png" />
 
   <!-- Styles -->
@@ -192,7 +192,7 @@
                   color: #6b6b6b;
                   text-align: center;
                 ">
-              Elevate your Sessh
+              Experience euphoria
             </h2>
             <div class="line"></div>
           </div>

--- a/map/index.html
+++ b/map/index.html
@@ -8,13 +8,13 @@
   <script src="https://api.tiles.mapbox.com/mapbox-gl-js/v2.9.2/mapbox-gl.js"></script>
   <link href="https://api.tiles.mapbox.com/mapbox-gl-js/v2.9.2/mapbox-gl.css" rel="stylesheet" />
   <meta name="title" content="Apparel — Sesshin" />
-  <meta name="description" content="Elevate Your Sessh" />
+  <meta name="description" content="Experience euphoria" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
   <meta property="og:url" content="" />
   <meta property="og:title" content="Find Us — Sesshin" />
-  <meta property="og:description" content="Elevate Your Sessh" />
+  <meta property="og:description" content="Experience euphoria" />
   <meta property="og:image" content="https://i.ibb.co/yfWpmF9/sesshin.png" />
   <meta property="og:site_name" content="Apparel — Sesshin" />
 
@@ -22,7 +22,7 @@
   <meta property="twitter:card" content="summary_large_image" />
   <meta property="twitter:url" content="" />
   <meta property="twitter:title" content="Find Us — Sesshin" />
-  <meta property="twitter:description" content="Elevate Your Sessh" />
+  <meta property="twitter:description" content="Experience euphoria" />
   <meta property="twitter:image" content="https://i.ibb.co/yfWpmF9/sesshin.png" />
 
   <!-- Styles -->

--- a/products/index.html
+++ b/products/index.html
@@ -8,13 +8,13 @@
   <!-- Primary Meta Tags -->
   <title>Products — Sesshin</title>
   <meta name="title" content="Products — Sesshin" />
-  <meta name="description" content="Elevate Your Sessh" />
+  <meta name="description" content="Experience euphoria" />
 
   <!-- Open Graph / Facebook -->
   <meta property="og:type" content="website" />
   <meta property="og:url" content="" />
   <meta property="og:title" content="Products — Sesshin" />
-  <meta property="og:description" content="Elevate Your Sessh" />
+  <meta property="og:description" content="Experience euphoria" />
   <meta property="og:image" content="https://i.ibb.co/yfWpmF9/sesshin.png" />
   <meta property="og:site_name" content="Products — Sesshin" />
 
@@ -22,7 +22,7 @@
   <meta property="twitter:card" content="summary_large_image" />
   <meta property="twitter:url" content="" />
   <meta property="twitter:title" content="Products — Sesshin" />
-  <meta property="twitter:description" content="Elevate Your Sessh" />
+  <meta property="twitter:description" content="Experience euphoria" />
   <meta property="twitter:image" content="https://i.ibb.co/yfWpmF9/sesshin.png" />
 
 
@@ -220,7 +220,7 @@
                     color: #6b6b6b;
                     text-align: center;
                   ">
-              Elevate your Sessh
+              Experience euphoria
             </h2>
             <div class="line"></div>
           </div>


### PR DESCRIPTION
This PR converts the images on the `/apparel/` page to a link that leads to another page.

> Screenshot showing a link at the bottom-left of the page and the cursor as a pointer when hovering on an image.

![Apparel](https://user-images.githubusercontent.com/87664239/206462481-118bb1e4-7a28-4f2f-a0fa-7c3875cce953.png)

### Other Changes (from _a day before..._)

- Update meta description and image across all pages.

